### PR TITLE
Tried to implement command_missing

### DIFF
--- a/lib/optitron/class_dsl.rb
+++ b/lib/optitron/class_dsl.rb
@@ -203,8 +203,9 @@ class Optitron
         if response.valid?
           optitron_parser.target.params = response.params
           args = response.args
-          while (args.size < optitron_parser.commands.assoc(response.command).last.args.size)
-            args << optitron_parser.commands.assoc(response.command).last.args[args.size].default
+          parser_args = optitron_parser.commands.assoc(response.command).last.args
+          while (args.size < parser_args.size && !(parser_args[args.size].type == :greedy && parser_args[args.size].default.nil?))
+            args << parser_args[args.size].default 
           end
 
           optitron_parser.target.send(response.command.to_sym, *response.args)

--- a/lib/optitron/class_dsl.rb
+++ b/lib/optitron/class_dsl.rb
@@ -206,8 +206,11 @@ class Optitron
           while (args.size < optitron_parser.commands.assoc(response.command).last.args.size)
             args << optitron_parser.commands.assoc(response.command).last.args[args.size].default
           end
+
           optitron_parser.target.send(response.command.to_sym, *response.args)
         else
+          puts optitron_parser.help
+
           unless response.args.empty?
             puts response.error_messages.join("\n")
           end

--- a/lib/optitron/parser.rb
+++ b/lib/optitron/parser.rb
@@ -42,7 +42,6 @@ class Optitron
           options += @commands.assoc(response.command).last.options
           args = @commands.assoc(response.command).last.args
         else
-          puts help
           potential_cmd_toks.first ?
             response.add_error('an unknown command', potential_cmd_toks.first.lit) :
             response.add_error('unknown command')

--- a/lib/optitron/parser.rb
+++ b/lib/optitron/parser.rb
@@ -27,7 +27,7 @@ class Optitron
           response.command = cmd_tok.lit
           options += @commands.assoc(cmd_tok.lit).last.options
           args = @commands.assoc(cmd_tok.lit).last.args
-        elsif @target.respond_to?(:command_missing)
+        elsif !potential_cmd_toks.empty? && @target.respond_to?(:command_missing)
           command = potential_cmd_toks.first.lit
           response.command = 'command_missing'
           @commands << [response.command, Option::Cmd.new(response.command)]


### PR DESCRIPTION
I needed the chance to do something when the command wasn't found and I couldn't find a better way, I'd like this to be included so I can use the gem in my package manager.

I'm failing at getting rake to work with RSpec so I couldn't implement a spec for it, but if you want an example you can find it [here](https://github.com/distro/packo/blob/master/bin/packo-select).

If there's already a simple way to achieve what I need I'll be glad to use it :) 

Thank you and sorry for the trouble.
